### PR TITLE
Fix image status from 304 to 200

### DIFF
--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -58,7 +58,7 @@ export default function CategoryPage({ params }: CategoryPageProps) {
               >
                 <div className="relative w-full aspect-[4/3]">
                   <Image
-                    src={s.coverImage || s.images[0]}
+                    src={`${s.coverImage || s.images[0]}?t=${Date.now()}`}
                     alt={s.title}
                     fill
                     className="object-cover group-hover:scale-105 transition-transform duration-500"

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,9 @@
 import Image from "next/image"
 
 export default function AboutPage() {
+  // Add cache-busting timestamp to prevent 304 responses
+  const cacheBustingSrc = `/images/about/IMG_9118.PNG?t=${Date.now()}`
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-6 py-12">
@@ -8,7 +11,7 @@ export default function AboutPage() {
           <div className="grid md:grid-cols-2 gap-12 items-start">
             {/* Photo */}
             <div className="relative aspect-[4/5] overflow-hidden rounded-sm shadow-sm">
-              <Image src="/images/about/IMG_9118.PNG" alt="Photographer portrait" fill className="object-cover" />
+              <Image src={cacheBustingSrc} alt="Photographer portrait" fill className="object-cover" />
             </div>
 
             {/* Bio */}

--- a/components/lazy-image.tsx
+++ b/components/lazy-image.tsx
@@ -16,6 +16,9 @@ export function LazyImage({ src, alt, aspectRatio, priority = false, className =
   const [isInView, setIsInView] = useState(false)
   const imgRef = useRef<HTMLDivElement>(null)
 
+  // Add cache-busting timestamp to prevent 304 responses
+  const cacheBustingSrc = src ? `${src}?t=${Date.now()}` : "/images/placeholder-logo.jpg"
+
   useEffect(() => {
     if (priority) {
       setIsInView(true)
@@ -56,7 +59,7 @@ export function LazyImage({ src, alt, aspectRatio, priority = false, className =
         {/* Image */}
         {isInView && (
           <Image
-            src={src || "/images/placeholder-logo.jpg"}
+            src={cacheBustingSrc}
             alt={alt}
             fill
             className={`object-contain group-hover:scale-105 transition-transform duration-500 ${

--- a/components/masonry-image.tsx
+++ b/components/masonry-image.tsx
@@ -18,6 +18,9 @@ export function MasonryImage({ src, alt, priority = false, className = "" }: Mas
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null)
   const imgRef = useRef<HTMLDivElement>(null)
 
+  // Add cache-busting timestamp to prevent 304 responses
+  const cacheBustingSrc = src ? `${src}?t=${Date.now()}` : "/images/placeholder-logo.jpg"
+
   useEffect(() => {
     if (priority) {
       setIsInView(true)
@@ -71,7 +74,7 @@ export function MasonryImage({ src, alt, priority = false, className = "" }: Mas
           {/* Image */}
           {isInView && (
             <Image
-              src={src || "/images/placeholder-logo.jpg"}
+              src={cacheBustingSrc}
               alt={alt}
               fill
               className={`object-cover group-hover:scale-105 transition-transform duration-500 ${
@@ -99,7 +102,7 @@ export function MasonryImage({ src, alt, priority = false, className = "" }: Mas
       {!imageDimensions && isInView && (
         <div className="relative w-full aspect-[4/3]">
           <Image
-            src={src || "/images/placeholder-logo.jpg"}
+            src={cacheBustingSrc}
             alt={alt}
             fill
             className="object-contain opacity-0"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,46 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    return [
+      {
+        // Apply headers to all images in the public/images directory
+        source: '/images/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+          {
+            key: 'Pragma',
+            value: 'no-cache',
+          },
+          {
+            key: 'Expires',
+            value: '0',
+          },
+        ],
+      },
+      {
+        // Apply headers to all images in the public directory
+        source: '/:path*.(jpg|jpeg|png|gif|svg|webp|ico)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+          {
+            key: 'Pragma',
+            value: 'no-cache',
+          },
+          {
+            key: 'Expires',
+            value: '0',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Force images to return 200 OK status by disabling caching and adding cache-busting.

This PR addresses the user's request to prevent images from returning a 304 'Not Modified' status. While 304 is standard caching behavior, the changes ensure images are always re-downloaded, resulting in a 200 OK status, by implementing server-side cache control headers and client-side cache-busting timestamps on image URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c4f5f7b-7413-4733-8474-ee0776183fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c4f5f7b-7413-4733-8474-ee0776183fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>