### PR TITLE
Adjust portrait theater photos to cards

### DIFF
--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -56,12 +56,12 @@ export default function CategoryPage({ params }: CategoryPageProps) {
                 href={`/${cat.slug}/${s.slug}`}
                 className="group block overflow-hidden rounded-lg shadow hover:shadow-lg transition bg-card"
               >
-                <div className="relative w-full aspect-[4/3]">
+                <div className="relative w-full aspect-[4/3] bg-neutral-100">
                   <Image
                     src={s.coverImage || s.images[0]}
                     alt={s.title}
                     fill
-                    className="object-cover group-hover:scale-105 transition-transform duration-500"
+                    className="object-contain"
                   />
                 </div>
                 <div className="p-4">


### PR DESCRIPTION
Fix image cropping on category cards by using `object-contain` and removing hover zoom.

---
<a href="https://cursor.com/background-agent?bcId=bc-19660ab0-5261-402c-9002-c03b0884de40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19660ab0-5261-402c-9002-c03b0884de40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

